### PR TITLE
Show the number of comments only for the posts that have the comments open

### DIFF
--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -116,9 +116,11 @@ $post_id = get_the_ID();
 					}
 					?>
 					</span><!-- End .entry-tags -->
+				<?php if ( comments_open() ) { ?>
 				<span class="entry-separator">/</span>
 				<a href="#"
 					class="entry-comments"><?php comments_number( esc_html__( 'No Responses', 'islemag' ), esc_html__( 'One Response', 'islemag' ), esc_html__( '% Responses', 'islemag' ) ); ?></a>
+				<?php } ?>
 				<span class="entry-separator">/</span>
 				<?php esc_html_e( 'by', 'islemag' ); ?> <a
 						href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"

--- a/template-parts/content-template1.php
+++ b/template-parts/content-template1.php
@@ -56,8 +56,10 @@ if ( $wp_query->have_posts() ) : ?>
 			</figure> <!-- End figure -->
 			<div class="entry-overlay-meta">
 				<span class="entry-overlay-date"><i class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+				<?php if ( comments_open() ) { ?>
 				<span class="entry-separator">/</span>
 				<a href="<?php the_permalink(); ?>" class="entry-comments"><i class="fa fa-comments"></i><?php comments_number( '0', '1', '%' ); ?></a>
+				<?php } ?>
 				<span class="entry-separator">/</span>
 				<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" class="entry-author"><i class="fa fa-user"></i><?php the_author(); ?></a>
 			</div> <!-- End .entry-overlay-meta -->

--- a/template-parts/content-template2.php
+++ b/template-parts/content-template2.php
@@ -82,9 +82,11 @@ if ( $wp_query->have_posts() ) : ?>
 						<div class="entry-meta">
 							<span class="entry-overlay-date"><i
 										class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+							<?php if ( comments_open() ) { ?>
 							<span class="entry-separator">/</span>
 							<a href="<?php the_permalink(); ?>"
 								class="entry-comments"><?php comments_number( esc_html__( '0 Comments', 'islemag' ), esc_html__( '1 Comment', 'islemag' ), esc_html__( '% Comments', 'islemag' ) ); ?></a>
+							<?php } ?>
 							<div>
 								<?php esc_html_e( 'Posted By', 'islemag' ); ?><a
 										href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"

--- a/template-parts/content-template3.php
+++ b/template-parts/content-template3.php
@@ -66,9 +66,11 @@ if ( $wp_query->have_posts() ) : ?>
 							<div class="entry-overlay-meta">
 								<span class="entry-overlay-date"><i
 											class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+								<?php if ( comments_open() ) { ?>
 								<span class="entry-separator">/</span>
 								<a href="<?php the_permalink(); ?>" class="entry-comments"><i
 											class="fa fa-comments"></i><?php comments_number( '0', '1', '%' ); ?></a>
+								<?php } ?>
 								<span class="entry-separator">/</span>
 								<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"
 									class="entry-author"><i class="fa fa-user"></i><?php the_author(); ?></a>
@@ -166,9 +168,11 @@ if ( $wp_query->have_posts() ) : ?>
 					<div class="entry-meta">
 						<span class="entry-overlay-date"><i
 									class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+						<?php if ( comments_open() ) { ?>
 						<span class="entry-separator">/</span>
 						<a href="<?php the_permalink(); ?>"
 							class="entry-comments"><?php comments_number( esc_html__( '0 Comments', 'islemag' ), esc_html__( '1 Comment', 'islemag' ), esc_html__( '% Comments', 'islemag' ) ); ?></a>
+						<?php } ?>
 						<div>
 							<?php esc_html_e( 'Posted By', 'islemag' ); ?><a
 									href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"
@@ -241,9 +245,11 @@ if ( $wp_query->have_posts() ) : ?>
 					<div class="entry-meta">
 						<span class="entry-overlay-date"><i
 									class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+						<?php if ( comments_open() ) { ?>
 						<span class="entry-separator">/</span>
 						<a href="<?php the_permalink(); ?>"
 							class="entry-comments"><?php comments_number( esc_html__( '0 Comments', 'islemag' ), esc_html__( '1 Comment', 'islemag' ), esc_html__( '% Comments', 'islemag' ) ); ?></a>
+						<?php } ?>
 						<div>
 							<?php esc_html_e( 'Posted By', 'islemag' ); ?><a
 									href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"
@@ -313,9 +319,11 @@ if ( $wp_query->have_posts() ) : ?>
 					<div class="entry-meta">
 						<span class="entry-overlay-date"><i
 									class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+						<?php if ( comments_open() ) { ?>
 						<span class="entry-separator">/</span>
 						<a href="<?php the_permalink(); ?>"
 							class="entry-comments"><?php comments_number( esc_html__( '0 Comments', 'islemag' ), esc_html__( '1 Comment', 'islemag' ), esc_html__( '% Comments', 'islemag' ) ); ?></a>
+						<?php } ?>
 						<div>
 							<?php esc_html_e( 'Posted By', 'islemag' ); ?><a
 									href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"

--- a/template-parts/content-template4.php
+++ b/template-parts/content-template4.php
@@ -85,9 +85,11 @@ if ( $wp_query->have_posts() ) :
 							<div class="entry-meta">
 							<span class="entry-overlay-date"><i
 									class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+						<?php if ( comments_open() ) { ?>
 						<span class="entry-separator">/</span>
 						<a href="<?php the_permalink(); ?>"
 							class="entry-comments"><?php comments_number( esc_html__( '0 Comments', 'islemag' ), esc_html__( '1 Comment', 'islemag' ), esc_html__( '% Comments', 'islemag' ) ); ?></a>
+						<?php } ?>
 						<div>
 							<?php esc_html_e( 'Posted By', 'islemag' ); ?><a
 									href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"
@@ -157,9 +159,11 @@ if ( $wp_query->have_posts() ) :
 						<div class="entry-meta">
 						<span class="entry-overlay-date"><i
 								class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+					<?php if ( comments_open() ) { ?>
 					<span class="entry-separator">/</span>
 					<a href="#"
 						class="entry-comments"><?php comments_number( esc_html__( '0 Comments', 'islemag' ), esc_html__( '1 Comment', 'islemag' ), esc_html__( '% Comments', 'islemag' ) ); ?></a>
+					<?php } ?>
 					<div>
 						<?php esc_html_e( 'Posted By', 'islemag' ); ?><a
 								href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"

--- a/template-parts/slider-posts.php
+++ b/template-parts/slider-posts.php
@@ -39,8 +39,10 @@ $choosed_color = array_rand( $colors, 1 );
 	<div class="entry-overlay-meta">
 		<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>', apply_filters( 'islemag_filter_article_title_on_slider_posts', true ) ); ?>
 		<span class="entry-overlay-date"><i class="fa fa-calendar"></i><?php echo get_the_date( 'j M' ); ?></span>
+		<?php if ( comments_open() ) { ?>
 		<span class="entry-separator">/</span>
 		<a href="<?php the_permalink(); ?>" class="entry-comments"><i class="fa fa-comments"></i><?php comments_number( '0', '1', '%' ); ?></a>
+		<?php } ?>
 		<span class="entry-separator">/</span>
 		<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" class="entry-author"><i class="fa fa-user"></i><?php the_author(); ?></a>
 	</div><!-- End .entry-overlay-meta -->


### PR DESCRIPTION
If the site closes the comments (for some posts or for all posts) it is useless and even embarrassing to display `0 Comments` all over the place.

This PR displays the number of comments only for the posts that have the comments open.